### PR TITLE
Fix/eslint jsdoc check param names

### DIFF
--- a/amd.js
+++ b/amd.js
@@ -31,7 +31,7 @@ module.exports = {
         'implicit-arrow-linebreak': ['error'],
         indent: ['warn', 4, { SwitchCase: 1, MemberExpression: 'off' }],
         'jsdoc/check-alignment': ['warn'],
-        'jsdoc/check-param-names': ['warn'],
+        'jsdoc/check-param-names': ['warn', { disableExtraPropertyReporting: true }],
         'jsdoc/require-param': ['warn'],
         'jsdoc/require-param-name': ['warn'],
         'jsdoc/require-param-type': ['warn'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@oat-sa/eslint-config-tao",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/eslint-config-tao",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shareable `.eslintrc` configurations package for `oat-sa` projects.",
   "main": "index.js",
   "scripts": {},

--- a/svelte.js
+++ b/svelte.js
@@ -33,7 +33,7 @@ module.exports = {
         'implicit-arrow-linebreak': ['error'],
         indent: ['warn', 4, { SwitchCase: 1, MemberExpression: 'off' }],
         'jsdoc/check-alignment': ['warn'],
-        'jsdoc/check-param-names': ['warn'],
+        'jsdoc/check-param-names': ['warn', { disableExtraPropertyReporting: true }],
         'jsdoc/require-param': ['warn'],
         'jsdoc/require-param-name': ['warn'],
         'jsdoc/require-param-type': ['warn'],


### PR DESCRIPTION
This change makes JSDoc linting less strict for the nested documented property in the following code example:
```
/**
 * Match function that pass parameters to worker process and waits for its result.
 * @param {object} parameters
 * @param {RegExp} parameters.pattern RegExp object that should be matched
 * @param {string} parameters.text Text that should be matched against the pattern
 * @param {object} parameters.options
 * @param {number} parameters.options.timeout Timeout in miliseconds // WARNING: @param "parameters.options.timeout" does not exist on parameter
 * @param {(err, result) => void} callback
 * @returns {function} - Returns with a terminate function to be able to terminate worker
 */
export default ({pattern, text, options = {}}, callback) => {
```

This warning came up after updating `eslint-plugin-jsdoc` to v31 in https://github.com/oat-sa/live-design-system/pull/437