### PR TITLE
fix: add jest recommended config

### DIFF
--- a/node.js
+++ b/node.js
@@ -14,7 +14,7 @@ module.exports = {
             mode: 'jsdoc'
         }
     },
-    extends: 'eslint:recommended',
+    extends: ['eslint:recommended', 'plugin:jest/recommended'],
     rules: {
         'array-bracket-newline': ['warn', 'consistent'],
         'arrow-body-style': ['error', 'as-needed'],

--- a/svelte.js
+++ b/svelte.js
@@ -5,7 +5,7 @@ module.exports = {
         es2024: true,
         'jest/globals': true
     },
-    extends: ['eslint:recommended', 'plugin:svelte/recommended'],
+    extends: ['eslint:recommended', 'plugin:jest/recommended', 'plugin:svelte/recommended'],
     plugins: ['es', 'jsdoc', 'jest'],
     parser: '@babel/eslint-parser',
     parserOptions: {


### PR DESCRIPTION
Jest globals and jest rules weren't enabled in 3.0.0.
This fix makes the jest plugin work