### PR TITLE
Fix/FUN-1899/turn off annoying rules

### DIFF
--- a/flat/frontend-rules.mjs
+++ b/flat/frontend-rules.mjs
@@ -4,7 +4,7 @@ export default {
     eqeqeq: ['error', 'smart'],
     'no-alert': ['error'],
     'no-caller': ['error'],
-    'no-console': ['error'],
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-duplicate-imports': ['error'],
     'no-eval': ['error'],
     'no-extend-native': ['error'],

--- a/flat/jest.mjs
+++ b/flat/jest.mjs
@@ -6,6 +6,10 @@ export default [
     {
         name: 'tao:jest',
         files: testFilesGlob,
-        ...jest.configs['flat/recommended']
+        ...jest.configs['flat/recommended'],
+        rules: {
+            'jest/expect-expect': ['off'],
+            'jest/no-done-callback': ['off'],
+        }
     }
 ];

--- a/svelte-base-legacy.js
+++ b/svelte-base-legacy.js
@@ -51,7 +51,7 @@ module.exports = {
         'no-alert': ['error'],
         'no-caller': ['error'],
         'no-confusing-arrow': ['error', { allowParens: false }],
-        'no-console': ['error'],
+        'no-console': ['error', { allow: ['warn', 'error'] }],
         'no-debugger': ['error'],
         'no-duplicate-imports': ['error'],
         'no-eval': ['error'],

--- a/svelte-jest-legacy.js
+++ b/svelte-jest-legacy.js
@@ -4,5 +4,9 @@ module.exports = {
         'jest/globals': true
     },
     extends: ['./svelte-base-legacy', 'plugin:jest/recommended'],
-    plugins: ['jest']
+    plugins: ['jest'],
+    rules: {
+        'jest/expect-expect': ['off'],
+        'jest/no-done-callback': ['off'],
+    }
 };


### PR DESCRIPTION
Suggestions to go on top of https://github.com/oat-sa/eslint-config-tao/pull/30 before it is released.

1. Turn off the 2 `jest/recommended` rules we are violating most frequently in big projects (reasoning provided below). I checked all the other jest rules and what kind of code was triggering them, and I think they can all be fixed or selectively disabled.
2. Loosen the `no-console` rule to allow `console.error`. I was reviewing `// eslint-disable ...` usages in our projects and this is one of the most common cases. Furthermore, I think it's counterproductive to tell developers they must not put an error in the console. Doing so will generally get problems discovered and fixed faster.
3. For `svelte/no-at-html` I elected to keep it as an error, to make sure we stay aware of the security risk. If we need to use that syntax 20 times in a project, we will just have to disable it locally 20 times - or overall for that project.